### PR TITLE
Fix ensure only apps can create users

### DIFF
--- a/actnow/accounts/authentication.py
+++ b/actnow/accounts/authentication.py
@@ -1,0 +1,29 @@
+from django.utils.translation import gettext_lazy as _
+from oauth2_provider.models import get_id_token_model
+from rest_framework import exceptions
+from rest_framework.authentication import TokenAuthentication
+
+
+class CustomApplicationAuthentication(TokenAuthentication):
+    """
+    Authenticates using JWT ID since we don't have a user associated
+    with an application that we can use to generate DRF Token.
+
+    Clients should authenticate by passing the token key in the "Authorization"
+    HTTP header, prepended with the string "Token ".  For example:
+
+        Authorization: Token 401f7ac837da42b97f613d789819ff93537bee6a
+
+    """
+
+    def authenticate_credentials(self, key):
+        model = get_id_token_model()
+        try:
+            token = model.objects.select_related("application").get(jti=key)
+        except Exception:
+            raise exceptions.AuthenticationFailed(_("Invalid token."))
+
+        if not token.is_valid:
+            raise exceptions.AuthenticationFailed(_("Application inactive or deleted."))
+
+        return (token.application, token)

--- a/actnow/accounts/permissions.py
+++ b/actnow/accounts/permissions.py
@@ -1,0 +1,11 @@
+from oauth2_provider.models import get_id_token_model
+from rest_framework.permissions import BasePermission
+
+
+class AllowAppicationsOnly(BasePermission):
+    def has_permission(self, request, view):
+        application_id_token = request.data.get("application_token")
+        jti = get_id_token_model().objects.filter(jti__iexact=application_id_token)
+        if not jti.exists():
+            return False
+        return jti.first().is_valid()

--- a/actnow/accounts/permissions.py
+++ b/actnow/accounts/permissions.py
@@ -1,11 +1,7 @@
-from oauth2_provider.models import get_id_token_model
+from oauth2_provider.models import Application
 from rest_framework.permissions import BasePermission
 
 
 class AllowAppicationsOnly(BasePermission):
     def has_permission(self, request, view):
-        application_id_token = request.data.get("application_token")
-        jti = get_id_token_model().objects.filter(jti__iexact=application_id_token)
-        if not jti.exists():
-            return False
-        return jti.first().is_valid()
+        return isinstance(request.user, Application)

--- a/actnow/accounts/tests/test_views.py
+++ b/actnow/accounts/tests/test_views.py
@@ -1,16 +1,26 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls.base import reverse
+from django.utils import timezone
+from oauth2_provider.models import get_application_model, get_id_token_model
 
 User = get_user_model()
 
 
 class TestUserRegistrationView(TestCase):
     def setUp(self):
+        self.application = get_application_model()()
+        self.application.save()
+        expires = timezone.now() + timezone.timedelta(seconds=10)
+        self.id_token = get_id_token_model()(
+            application=self.application, expires=expires
+        )
+        self.id_token.save()
         self.user_data = {
             "username": "TestUser",
             "email": "testuser@mail.com",
             "password": "RandomPassword#2323#",
+            "application_token": str(self.id_token.jti),
         }
         self.url = reverse("accounts-user_registration")
 
@@ -41,3 +51,9 @@ class TestUserRegistrationView(TestCase):
         )
         self.assertEqual(400, response.status_code)
         self.assertEqual(1, User.objects.count())
+
+    def test_only_apps_can_register_a_user(self):
+        user_data = {**self.user_data}
+        del user_data["application_token"]
+        response = self.client.post(self.url, user_data)
+        self.assertEqual(401, response.status_code)

--- a/actnow/accounts/tests/test_views.py
+++ b/actnow/accounts/tests/test_views.py
@@ -20,21 +20,27 @@ class TestUserRegistrationView(TestCase):
             "username": "TestUser",
             "email": "testuser@mail.com",
             "password": "RandomPassword#2323#",
-            "application_token": str(self.id_token.jti),
         }
+        self.HTTP_AUTHORIZATION = f"Token {str(self.id_token.jti)}"
         self.url = reverse("accounts-user_registration")
 
     def test_user_registration(self):
         self.assertEqual(0, User.objects.count())
-        response = self.client.post(self.url, self.user_data)
+        response = self.client.post(
+            self.url, self.user_data, HTTP_AUTHORIZATION=self.HTTP_AUTHORIZATION
+        )
         self.assertEqual(201, response.status_code)
         self.assertEqual(1, User.objects.count())
 
     def test_existing_email_returns_error(self):
-        self.client.post(self.url, self.user_data)
+        self.client.post(
+            self.url, self.user_data, HTTP_AUTHORIZATION=self.HTTP_AUTHORIZATION
+        )
         self.assertEqual(1, User.objects.count())
         self.user_data["username"] = "tester2"
-        response = self.client.post(self.url, self.user_data)
+        response = self.client.post(
+            self.url, self.user_data, HTTP_AUTHORIZATION=self.HTTP_AUTHORIZATION
+        )
         self.assertIn(
             b"A user is already registered with this e-mail address.", response.content
         )
@@ -42,10 +48,14 @@ class TestUserRegistrationView(TestCase):
         self.assertEqual(1, User.objects.count())
 
     def test_existing_username_returns_error(self):
-        self.client.post(self.url, self.user_data)
+        self.client.post(
+            self.url, self.user_data, HTTP_AUTHORIZATION=self.HTTP_AUTHORIZATION
+        )
         self.assertEqual(1, User.objects.count())
         self.user_data["email"] = "tester2@mail.com"
-        response = self.client.post(self.url, self.user_data)
+        response = self.client.post(
+            self.url, self.user_data, HTTP_AUTHORIZATION=self.HTTP_AUTHORIZATION
+        )
         self.assertIn(
             b"A user is already registered with this username", response.content
         )
@@ -54,6 +64,5 @@ class TestUserRegistrationView(TestCase):
 
     def test_only_apps_can_register_a_user(self):
         user_data = {**self.user_data}
-        del user_data["application_token"]
         response = self.client.post(self.url, user_data)
         self.assertEqual(401, response.status_code)

--- a/actnow/accounts/views.py
+++ b/actnow/accounts/views.py
@@ -30,9 +30,8 @@ class UserRegistrationView(CreateAPIView):
             return Response({"error": response}, status=response_status)
 
         user = serializer.save(self.request)
-        token = Token.objects.create(user=user)
+        Token.objects.create(user=user)
 
         return Response(
-            {"token": token.key},
             status=status.HTTP_201_CREATED,
         )

--- a/actnow/accounts/views.py
+++ b/actnow/accounts/views.py
@@ -6,11 +6,13 @@ from rest_framework.response import Response
 
 from actnow.accounts.serializers import UserRegistrationSerializer
 
+from .permissions import AllowAppicationsOnly
 from .utils import email_address_exists, username_exists
 
 
 class UserRegistrationView(CreateAPIView):
     serializer_class = UserRegistrationSerializer
+    permission_classes = [AllowAppicationsOnly]
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)

--- a/actnow/accounts/views.py
+++ b/actnow/accounts/views.py
@@ -6,13 +6,15 @@ from rest_framework.response import Response
 
 from actnow.accounts.serializers import UserRegistrationSerializer
 
+from .authentication import CustomApplicationAuthentication
 from .permissions import AllowAppicationsOnly
 from .utils import email_address_exists, username_exists
 
 
 class UserRegistrationView(CreateAPIView):
     serializer_class = UserRegistrationSerializer
-    permission_classes = [AllowAppicationsOnly]
+    authentication_classes = (CustomApplicationAuthentication,)
+    permission_classes = (AllowAppicationsOnly,)
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)


### PR DESCRIPTION
## Description

Ensures only apps can create a user account by sending an application token.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
<img width="1376" alt="Screenshot 2021-06-16 at 05 33 29" src="https://user-images.githubusercontent.com/13068580/122149227-69ae1580-ce64-11eb-9e98-25b374a71471.png">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
