### PR TITLE
[Fix] User accounts defaults

### DIFF
--- a/actnow/accounts/models.py
+++ b/actnow/accounts/models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.contrib.auth.models import (
     AbstractBaseUser,
     BaseUserManager,
@@ -13,20 +15,19 @@ from actnow.db.models import TimestampedModelMixin
 
 
 class ActNowUserManager(BaseUserManager):
-    def create_user(self, email, password=None, **extra_fields):
+    def _create_user(self, email, password, **extra_fields):
         if not email:
             raise ValueError("Users must have an email address")
 
         email = self.normalize_email(email)
-        # Since Users have to login in order to complete OAuth.
-        # They will have no permission to see anything in the admin dashboard.
-        is_staff = extra_fields.pop("is_staff", True)
-        is_active = extra_fields.pop("is_active", True)
-        is_superuser = extra_fields.pop("is_superuser", False)
-        username = extra_fields.pop("username", "").strip()
+        username = extra_fields.get("username", "").strip()
+        # Ensure we have a username
         if not username:
-            username = None
+            username = uuid.uuid4().hex
 
+        is_staff = extra_fields.pop("is_staff")
+        is_active = extra_fields.pop("is_active")
+        is_superuser = extra_fields.pop("is_superuser")
         user = self.model(
             email=email,
             username=username,
@@ -34,11 +35,25 @@ class ActNowUserManager(BaseUserManager):
             is_staff=is_staff,
             is_superuser=is_superuser,
         )
-
         user.set_password(password)
+
+        # Pass on username
+        extra_fields["username"] = username
         user.extra_fields = extra_fields
         user.save(using=self._db)
         return user
+
+    def create_user(self, email, password=None, **extra_fields):
+        if not email:
+            raise ValueError("Users must have an email address")
+
+        email = self.normalize_email(email)
+        # is_staff is required to login in order to complete OAuth.
+        extra_fields["is_staff"] = True
+        extra_fields["is_active"] = True
+        extra_fields["is_superuser"] = False
+
+        return self._create_user(email=email, password=password, **extra_fields)
 
     def create_superuser(self, email, password=None, **extra_fields):
         extra_fields.setdefault("is_staff", True)
@@ -50,7 +65,7 @@ class ActNowUserManager(BaseUserManager):
         if extra_fields.get("is_superuser") is not True:
             raise ValueError("Superuser must have is_superuser=True.")
 
-        return self.create_user(email, password, **extra_fields)
+        return self._create_user(email, password, **extra_fields)
 
 
 class ActNowUser(AbstractBaseUser, PermissionsMixin, TimestampedModelMixin):

--- a/actnow/accounts/models.py
+++ b/actnow/accounts/models.py
@@ -44,10 +44,6 @@ class ActNowUserManager(BaseUserManager):
         return user
 
     def create_user(self, email, password=None, **extra_fields):
-        if not email:
-            raise ValueError("Users must have an email address")
-
-        email = self.normalize_email(email)
         # is_staff is required to login in order to complete OAuth.
         extra_fields["is_staff"] = True
         extra_fields["is_active"] = True

--- a/actnow/accounts/tests/test_models.py
+++ b/actnow/accounts/tests/test_models.py
@@ -66,7 +66,7 @@ class ActNowUserTests(TestCase):
                 username="noemailuser", password="RandomPassword321"
             )
 
-    def test_user_email_is_unique(self):
+    def test_email_is_unique(self):
         self.User.objects.create_user(
             email="user@email.com", username="user1", password="RandomPassword1"
         )
@@ -77,11 +77,11 @@ class ActNowUserTests(TestCase):
 
     def test_username_is_unique(self):
         self.User.objects.create_user(
-            email="user1@gmail.com", username="user", password="RandomPassword1"
+            email="user1@email.com", username="user", password="RandomPassword1"
         )
         with self.assertRaises(IntegrityError):
             self.User.objects.create_user(
-                email="user2@gmail.com",
+                email="user2@email.com",
                 username="user",
                 password="RandomPassword2",
             )

--- a/actnow/accounts/tests/test_models.py
+++ b/actnow/accounts/tests/test_models.py
@@ -11,30 +11,53 @@ class ActNowUserTests(TestCase):
 
     def test_create_user(self):
         user = self.User.objects.create_user(
-            email="root@root.com",
+            email="user@email.com",
+            username="user",
             password="RandomPassword321",
-            username="root",
-            # is_superuser must always be set to false False in create_user
+            # is_superuser must always be set to False in create_user
             # regardless of what value was passed in.
             is_superuser=True,
         )
 
         # If username is provided, it must be preserved
-        self.assertIs(user.username, "root")
+        self.assertEqual(user.username, "user")
+        self.assertEqual(user.email, "user@email.com")
         self.assertTrue(user.is_active)
         self.assertTrue(user.is_staff)
         self.assertFalse(user.is_superuser)
 
-    def test_create_superuser(self):
-        user = self.User.objects.create_superuser(
-            email="root@root.com", password="RandomPassword321", username="root"
+    def test_create_user_without_username(self):
+        user = self.User.objects.create_user(
+            email="user@email.com", password="RandomPassword321"
         )
 
-        # If no username is provided, uuid4 will be used
+        # If no username was provided, uuid4 must be used to generate a random
+        # username.
         self.assertIsNotNone(user.username)
-        self.assertIs(uuid.UUID(user.username).version, 4)
+        self.assertEqual(uuid.UUID(user.username).version, 4)
+        self.assertFalse(user.is_superuser)
+
+    def test_create_superuser(self):
+        user = self.User.objects.create_superuser(
+            email="root@email.com", username="root", password="RandomPassword321"
+        )
+
+        # If username is provided, it must be preserved
+        self.assertEqual(user.username, "root")
+        self.assertEqual(user.email, "root@email.com")
         self.assertTrue(user.is_active)
         self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
+
+    def test_create_superuser_without_username(self):
+        user = self.User.objects.create_superuser(
+            email="root@email.com", password="RandomPassword321"
+        )
+
+        # If no username was provided, uuid4 must be used to generate a random
+        # username.
+        self.assertIsNotNone(user.username)
+        self.assertEqual(uuid.UUID(user.username).version, 4)
         self.assertTrue(user.is_superuser)
 
     def test_email_is_required(self):
@@ -45,20 +68,20 @@ class ActNowUserTests(TestCase):
 
     def test_user_email_is_unique(self):
         self.User.objects.create_user(
-            email="user@user.com", username="user", password="RandomPassword321"
+            email="user@email.com", username="user1", password="RandomPassword1"
         )
         with self.assertRaises(IntegrityError):
             self.User.objects.create_user(
-                email="user@user.com", username="user", password="RandomPassword321"
+                email="user@email.com", username="user2", password="RandomPassword2"
             )
 
     def test_username_is_unique(self):
         self.User.objects.create_user(
-            username="butcher", email="butcher1@gmail.com", password="RandomPassword321"
+            email="user1@gmail.com", username="user", password="RandomPassword1"
         )
         with self.assertRaises(IntegrityError):
             self.User.objects.create_user(
-                username="butcher",
-                email="butcher2@gmail.com",
-                password="RandomPassword321",
+                email="user2@gmail.com",
+                username="user",
+                password="RandomPassword2",
             )

--- a/actnow/accounts/tests/test_models.py
+++ b/actnow/accounts/tests/test_models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.contrib.auth import get_user_model
 from django.db.utils import IntegrityError
 from django.test import TestCase
@@ -9,8 +11,16 @@ class ActNowUserTests(TestCase):
 
     def test_create_user(self):
         user = self.User.objects.create_user(
-            email="root@root.com", password="RandomPassword321", username="root"
+            email="root@root.com",
+            password="RandomPassword321",
+            username="root",
+            # is_superuser must always be set to false False in create_user
+            # regardless of what value was passed in.
+            is_superuser=True,
         )
+
+        # If username is provided, it must be preserved
+        self.assertIs(user.username, "root")
         self.assertTrue(user.is_active)
         self.assertTrue(user.is_staff)
         self.assertFalse(user.is_superuser)
@@ -19,6 +29,10 @@ class ActNowUserTests(TestCase):
         user = self.User.objects.create_superuser(
             email="root@root.com", password="RandomPassword321", username="root"
         )
+
+        # If no username is provided, uuid4 will be used
+        self.assertIsNotNone(user.username)
+        self.assertIs(uuid.UUID(user.username).version, 4)
         self.assertTrue(user.is_active)
         self.assertTrue(user.is_staff)
         self.assertTrue(user.is_superuser)

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,9 +1,9 @@
-boto3==1.18.1
+boto3==1.18.6
 django-filter==2.4.0
 django-oauth-toolkit==1.5.0
 django-phonenumber-field[phonenumberslite]==5.2.0
 django-storages==1.11.1
-Django[argon2,bcrypt]==3.2.4
+Django[argon2,bcrypt]==3.2.5
 djangorestframework==3.12.4
 environs[django]==9.3.2
 greenlet==1.1.0
@@ -11,6 +11,5 @@ gunicorn[gevent,setproctitle]==20.1.0
 hyperlink==21.0.0
 markdown==3.3.4
 Pillow==8.3.1
-python-dotenv==0.18.0
 sentry-sdk==1.3.0
 setuptools_scm[toml]==6.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ install_requires =
     greenlet==1.0
     gunicorn[gevent,setproctitle]==20.1
     markdown==3.3
-    python-dotenv==0.18.0
 python_requires = >=3.8, <4
 packages = find:
 


### PR DESCRIPTION
## Description

By default:

  - [x] create_user must always create a non-admin account (`is_superuser = False`), and
  - [x] A random `username` must always be generate if no `username` was provided (use [`UUID.hex`](https://docs.python.org/3/library/uuid.html#uuid.UUID.hex)).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change which does not add visible functionality but improves code quality)

## Screenshots

![Screenshot from 2021-07-26 12-28-11](https://user-images.githubusercontent.com/1779590/126966769-40b90d18-1446-4017-8997-5bb68d25a01c.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

