### PR TITLE
[Chore] actnow.accounts cleanup

### DIFF
--- a/actnow/accounts/urls.py
+++ b/actnow/accounts/urls.py
@@ -1,5 +1,3 @@
-from django.urls import include, path
-from rest_framework.authtoken import views
 from rest_framework.routers import DefaultRouter
 
 from .views import UsersView
@@ -7,9 +5,4 @@ from .views import UsersView
 router = DefaultRouter()
 router.register(r"", UsersView, basename="accounts")
 
-urlpatterns = [
-    path("api-token-auth/", views.obtain_auth_token),
-    path("", include("django.contrib.auth.urls")),
-]
-
-urlpatterns += router.urls
+urlpatterns = router.urls

--- a/actnow/settings.py
+++ b/actnow/settings.py
@@ -57,7 +57,7 @@ INSTALLED_APPS = [
     "actnow.site",
 ]
 
-LOGIN_URL = "/accounts/login/"
+LOGIN_URL = "/admin/login/"
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
## Description

- [x] We no longer use Token authentication mechanism so `/accounts/api-token-auth` is no longer needed.
- [x] API browsing users should only be able to login throw `/admin/login`. Otherwise, they should login via OAuth.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (non-breaking change which does not add visible functionality but improves code quality)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
