### PR TITLE
Include profile id on returned user object

### DIFF
--- a/actnow/token.py
+++ b/actnow/token.py
@@ -12,7 +12,9 @@ class TokenView(OAuth2TokenView):
         token = get_access_token_model().objects.get(token=access_token)
         body["user"] = {
             "id": token.user.id,
-            "profile_id": token.user.userprofile.id,
+            "profile": {
+                "id": token.user.userprofile.id,
+            },
             "email": token.user.email,
             "username": token.user.username,
         }

--- a/actnow/token.py
+++ b/actnow/token.py
@@ -12,6 +12,7 @@ class TokenView(OAuth2TokenView):
         token = get_access_token_model().objects.get(token=access_token)
         body["user"] = {
             "id": token.user.id,
+            "profile_id": token.user.userprofile.id,
             "email": token.user.email,
             "username": token.user.username,
         }


### PR DESCRIPTION
## Description

Include profile id on the returned user object as requested [here](https://github.com/CodeForAfrica/PromiseTracker/pull/364#pullrequestreview-889316008)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
