### PR TITLE
[Fix] Pin allauth version to dj-rest-auth

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,6 +1,5 @@
 boto3==1.21.19
-dj-rest-auth==2.2.3
-django-allauth==0.49.0
+dj-rest-auth[with_social]==2.2.3
 django-filter==21.1
 django-oauth-toolkit==1.7.0
 django-phonenumber-field[phonenumberslite]==6.1.0


### PR DESCRIPTION
## Description

allauth seem to be introducing breaking changes from time to time & hence it's dangerous to use it without making sure it works with dj-rest-auth. See allauth [changelog](https://github.com/pennersr/django-allauth/blob/master/ChangeLog.rst).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change which does not add visible functionality but improves code quality)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

