### PR TITLE
Switch to bullseye in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ###############################################################################
 ## Python base image
 ###############################################################################
-FROM python:3.8-slim AS python-base
+FROM python:3.8-slim-bullseye AS python-base
 
 ### Arg
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ###############################################################################
 ## Python base image
 ###############################################################################
-FROM python:3.8-slim-bullseye AS python-base
+FROM python:3.10-slim-bullseye AS python-base
 
 ### Arg
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Description

Current base image has missing security updates which causes build to fail. This PR switches base image to bullseye variant.

Choice of variant: https://pythonspeed.com/articles/base-image-python-docker-images/

## Type of change

- [x] Chore (non-breaking change which does not add visible functionality but improves code quality)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
